### PR TITLE
fix: ensure footer text is white in light mode

### DIFF
--- a/frontend/latest/src/components/Footer.jsx
+++ b/frontend/latest/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 function Footer() {
   return (
     <footer className="bg-blue-600 dark:bg-gray-800 text-white p-4 text-center w-full mt-auto">
-      <p className="m-0 text-sm md:text-base">
+      <p className="m-0 text-sm md:text-base text-white">
         © 2025 Shuttle Tracker. All rights reserved
       </p>
     </footer>


### PR DESCRIPTION
Fixed the issue for footer color text in light mode .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text color consistency in the footer by explicitly setting paragraph text to white.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->