### PR TITLE
Add footer with correct routing using react-router-dom

### DIFF
--- a/frontend/latest/src/components/Footer.jsx
+++ b/frontend/latest/src/components/Footer.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { Home, MapPin, User } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
 function Footer() {
   return (
     <footer className="fixed bottom-0 left-0 w-full bg-blue-600 dark:bg-gray-800 text-white shadow-md z-50">
       <div className="flex justify-around items-center py-3">
-        <a href="/home" className="flex flex-col items-center text-sm text-white hover:opacity-80">
-          <Home size={24} color="white" />
-          <span className="text-white">Home</span>
-        </a>
-        <a href="/map" className="flex flex-col items-center text-sm text-white hover:opacity-80">
-          <MapPin size={24} color="white" />
-          <span className="text-white">Map</span>
-        </a>
-        <a href="/profile" className="flex flex-col items-center text-sm text-white hover:opacity-80">
-          <User size={24} color="white" />
-          <span className="text-white">Profile</span>
-        </a>
+        {/* Home */}
+        <Link to="/" className="flex flex-col items-center text-sm hover:opacity-80">
+          <Home size={24} />
+          <span>Home</span>
+        </Link>
+
+        {/* Track Shuttle */}
+        <Link to="/track-shuttle" className="flex flex-col items-center text-sm hover:opacity-80">
+          <MapPin size={24} />
+          <span>Track&nbsp;Shuttle</span>
+        </Link>
+
+        {/* Profile */}
+        <Link to="/driver" className="flex flex-col items-center text-sm hover:opacity-80">
+          <User size={24} />
+          <span>Profile</span>
+        </Link>
       </div>
     </footer>
   );
 }
+
 export default Footer;


### PR DESCRIPTION
Replaced anchor () tags in the footer with React Router components for proper client-side routing. Footer layout remains responsive and fixed at the bottom.
Fixes #64 